### PR TITLE
fix: resolve TypeError in getInsight - findOne().explain() is not a function

### DIFF
--- a/controllers/spendinsightController.js
+++ b/controllers/spendinsightController.js
@@ -21,10 +21,6 @@ export const getInsight = async (req, res) => {
                 1, 0, 0, 0
             ));
             const transactions = await db.collection("spendinginsight").find({ "bankAccountNumber": bankAccountNumber, "month": firstDayOfMonth }).toArray();
-            
-            // let explain = await db.collection("spendinginsight").find({ "bankAccountNumber": bankAccountNumber, "month": firstDayOfMonth }).explain("allPlansExecution")
-            // console.log(JSON.stringify(explain, null, 2));
-         
             if (transactions[0]) {
                 res.json(transactions);
             } else {
@@ -40,11 +36,15 @@ export const getInsight = async (req, res) => {
             }
         }
         else {
-            const transactions = await db.collection("spendinginsight").findOne();
-            res.json(transactions);
+            const transaction = await db.collection("spendinginsight").findOne();
+            if (transaction) {
+                res.json(transaction);
+            } else {
+                res.status(404).json({ message: "no insight data found" });
+            }
         }
     } catch (error) {
         console.error("Error fetching spending insight:", error);
-        res.status(500).json({ message: error });
+        res.status(500).json({ message: error.message });
     }
 };


### PR DESCRIPTION
## Problem

The `/api/insight` endpoint was returning HTTP 500 errors in production, detected via Grafana traces and logs.

**Error from application logs:**
```
TypeError: db.collection(...).findOne(...).explain is not a function
    at getInsight (controllers/spendinsightController.js:58:67)
```

**Root cause:** `findOne()` in the MongoDB Node.js driver returns a `Promise`, not a cursor. The `.explain()` method is only available on cursors returned by `find()`. Calling it on `findOne()` throws a `TypeError` and results in HTTP 500.

**Observed impact:**
- `/api/insight` error rate peaked at **1.2 req/s**
- Errors started escalating around 13:50 SGT
- Detected via Grafana Application Observability (`spending-insight2`, `status=error`)

## Changes

- **Remove** commented-out `.explain()` debug lines to prevent accidental re-introduction of the bug
- **Add** null/404 handling for the no-params `else` branch (`findOne()` with no filter)
- **Fix** error serialization in the `catch` block: use `error.message` instead of the raw `Error` object (which doesn't serialize to JSON correctly)

## Testing

- [ ] `GET /api/insight` returns 200 with valid data
- [ ] `GET /api/insight` returns 404 when no data exists
- [ ] No `TypeError` in application logs after fix